### PR TITLE
override emit route

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -52,7 +52,7 @@ Backbone.sync = function (method, model, options) {
   // If your socket.io connection exists on a different var, change here:
   var io = model.socket || window.socket || Backbone.socket;
 
-  io.emit(namespace + ':' + method, params.data, function (err, data) {
+  io.emit(params.req, params.data, function (err, data) {
     if (err) {
       options.error(err);
     } else {


### PR DESCRIPTION
small change, similar to the previous one

when calling io.emit in sync I thought we could use params.req instead of 

``` javascript
 namespace + ':' + method
```

This way the following line defined above in the code let user override the emit route if an option.req is passed

``` javascript
    var params = _.extend({
      req: namespace + ':' + method
    }, options);
```
