### PR TITLE
Preserve the semantics of the return value

### DIFF
--- a/lib/prefix.js
+++ b/lib/prefix.js
@@ -2,11 +2,13 @@
   // Common JS // require JS
   var _, Backbone, exports;
   if (typeof window === 'undefined' || typeof require === 'function') {
+    $ = require('jquery');
     _ = require('underscore');
     Backbone = require('backbone');
     exports = Backbone;
     if (module) module.exports = exports;
   } else {
+    $ = this.$;
     _ = this._;
     Backbone = this.Backbone;
     exports = this;

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -52,11 +52,15 @@ Backbone.sync = function (method, model, options) {
   // If your socket.io connection exists on a different var, change here:
   var io = model.socket || window.socket || Backbone.socket;
 
+  var defer = $.Deferred();
   io.emit(namespace + ':' + method, params.data, function (err, data) {
     if (err) {
       options.error(err);
+      defer.reject();
     } else {
       options.success(data);
+      defer.resolve();
     }
   });
+  return defer.promise();
 };


### PR DESCRIPTION
Backbone's sync method return an jqXHR object that implements the jQuery Promise interface.

To be compatible with the original Backbone's sync semantics, return a promise that is resolved on success and rejected on error.
