### PR TITLE
Using url of Model or Collection properly while constructing globalName in ioBind function

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -46,8 +46,9 @@ Backbone.Collection.prototype.ioBindVersion = '@VERSION';
  */
 
 Backbone.Collection.prototype.ioBind = function (eventName, io, callback, context) {
+  var url = typeof this.url === 'function' ? this.url() : this.url;
   var ioEvents = this._ioEvents || (this._ioEvents = {})
-    , globalName = this.url + ':' + eventName
+    , globalName = url + ':' + eventName
     , self = this;
   if ('function' == typeof io) {
     context = callback;

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -46,9 +46,8 @@ Backbone.Collection.prototype.ioBindVersion = '@VERSION';
  */
 
 Backbone.Collection.prototype.ioBind = function (eventName, io, callback, context) {
-  var url = typeof this.url === 'function' ? this.url() : this.url;
   var ioEvents = this._ioEvents || (this._ioEvents = {})
-    , globalName = url + ':' + eventName
+    , globalName = _.result(this, 'url') + ':' + eventName
     , self = this;
   if ('function' == typeof io) {
     context = callback;

--- a/lib/model.js
+++ b/lib/model.js
@@ -44,9 +44,8 @@ Backbone.Model.prototype.ioBindVersion = '@VERSION';
  */
 
 Backbone.Model.prototype.ioBind = function (eventName, io, callback, context) {
-  var url = typeof this.url === 'function' ? this.url() : this.url;
   var ioEvents = this._ioEvents || (this._ioEvents = {})
-    , globalName = url + ':' + eventName
+    , globalName = _.result(this, 'url') + ':' + eventName
     , self = this;
   if ('function' == typeof io) {
     context = callback;

--- a/lib/model.js
+++ b/lib/model.js
@@ -44,8 +44,9 @@ Backbone.Model.prototype.ioBindVersion = '@VERSION';
  */
 
 Backbone.Model.prototype.ioBind = function (eventName, io, callback, context) {
+  var url = typeof this.url === 'function' ? this.url() : this.url;
   var ioEvents = this._ioEvents || (this._ioEvents = {})
-    , globalName = this.url() + ':' + eventName
+    , globalName = url + ':' + eventName
     , self = this;
   if ('function' == typeof io) {
     context = callback;


### PR DESCRIPTION
Both Backbone's Model and Collection accept url attribute in either a string or a function. However, ioBind function defined in model.js and collection.js use different invoke method to construct globalName. And in this case, it restricts developer has to define url as a function in Model, and define url as a string in Collection only.

This commit is to solve this problem. Hope it be helpful to backbone.iobind project. Thanks for your great work to create such wonderful package!
