### PR TITLE
Add define() to UMD to make proper AMD package

### DIFF
--- a/lib/prefix.js
+++ b/lib/prefix.js
@@ -1,15 +1,7 @@
-(function (undefined) {
-  // Common JS // require JS
-  var _, $, Backbone, exports;
-  if (typeof window === 'undefined' || typeof require === 'function') {
-    $ = require('jquery');
-    _ = require('underscore');
-    Backbone = require('backbone');
-    exports = Backbone;
-    if (typeof module !== 'undefined') module.exports = exports;
-  } else {
-    $ = this.$;
-    _ = this._;
-    Backbone = this.Backbone;
-    exports = this;
+(function (factory) {
+  if (typeof exports === 'object') {
+    module.exports = factory(require('backbone'), require('underscore'));
+  } else if (typeof define === 'function' && define.amd) {
+    define(['backbone', 'underscore'], factory);
   }
+}(function (Backbone, _) {

--- a/lib/suffix.js
+++ b/lib/suffix.js
@@ -1,2 +1,2 @@
-
-})();
+  return Backbone;
+}));


### PR DESCRIPTION
Hi, this may not be the best, but I had to manually do this to get backbone.iobind to play nice with AMD. Requirejs is picky about seeing `define`.

Backbone UMD pattern taken from: https://github.com/thedersen/backbone.validation/blob/master/dist/backbone-validation-amd.js

With no `define()` I encounter the error:

`Uncaught Error: Module name "backbone.<moduleName>" has not been loaded yet for context: _. Use require([])`
