### PR TITLE
#50 use the full URL for namespace

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -36,8 +36,17 @@ Backbone.sync = function (method, model, options) {
     params.url = _.result(model, 'url') || urlError();
   }
 
-  var cmd = params.url.split('/')
-    , namespace = (cmd[0] !== '') ? cmd[0] : cmd[1]; // if leading slash, ignore
+  var cmd = params.url.split('/'),
+      namespace, i=1;
+  if(cmd[0] === ''){ // if leading slash, ignore
+    namespace = cmd[1];
+    i = 2;
+  } else {
+    namespace = cmd[0];
+  }
+  while( i < cmd.length){
+    namespace += '.' + cmd[i++];
+  }
 
   if ( !params.data && model ) {
     params.data = params.attrs || model.toJSON(options) || {};


### PR DESCRIPTION
In case the URL is multi leveled use the full URL for namespace.
