### PR TITLE
Added dependency for old version of folio (for the example)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -7,6 +7,7 @@
     "errorhandler": "^1.2.0",
     "express": "4.9.x",
     "fez": "0.0.x",
+    "folio": "^0.2.x",
     "jade": "1.7.x",
     "jquery": "1.11.x",
     "nib": "1.0.x",


### PR DESCRIPTION
`node examples/app.js` was failing because [folio](https://www.npmjs.com/package/folio) was not added as a dependency. The newer version of that module also fails due to a change in the API, so I've made it use the `0.2.x` branch.

I think a lot of this module needs cleaning up as the transition across from alogicparadox seems to have not really been all that successful (there are loads of broken links, incorrect links, just incorrect stuff in general!) and there's no bower.json file either (but I'll PR that separately).

I would like to be using this module in an active production environment so expect to receive many PRs in the future :smile: 

Cheers,
Maff
