### PR TITLE
Fix typo for using ajaxSync

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -69,7 +69,7 @@ var socketSync = function (method, model, options) {
 };
 
 var getSyncMethod = function(model) {
-  if (_.result(model.ajaxSync)) {
+  if (model.ajaxSync) {
     return ajaxSync;
   }
 


### PR DESCRIPTION
_.result(item, undefinded) is always undefined
