### PR TITLE
Unbind on destroy; improve unbind logic

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -99,15 +99,14 @@ Backbone.Collection.prototype.ioUnbind = function (eventName, io, callback) {
   }
   var events = ioEvents[eventName];
   if (!_.isEmpty(events)) {
-    if (callback && 'function' === typeof callback) {
-      for (var i = 0, l = events.length; i < l; i++) {
-        if (callback == events[i].cbLocal) {
-          this.unbind(events[i].name, events[i].cbLocal);
-          io.removeListener(events[i].global, events[i].cbGlobal);
-          events[i] = false;
+    if ('function' === typeof callback) {
+      _.each(events, function(event, index) {
+        if (callback == event.cbLocal) {
+          this.unbind(event.name, event.cbLocal);
+          io.removeListener(event.global, event.cbGlobal);
+          events.splice(index, 1);
         }
-      }
-      events = _.compact(events);
+      }, this);
     } else {
       this.unbind(eventName);
       io.removeAllListeners(globalName);

--- a/lib/model.js
+++ b/lib/model.js
@@ -64,6 +64,7 @@ Backbone.Model.prototype.ioBind = function (eventName, io, callback, context) {
   };
   this.bind(event.name, event.cbLocal, (context || self));
   io.on(event.global, event.cbGlobal);
+  this.once('destroy', _.bind(this.ioUnbind, this, event.name, io, event.cbLocal));
   if (!ioEvents[event.name]) {
     ioEvents[event.name] = [event];
   } else {
@@ -97,15 +98,14 @@ Backbone.Model.prototype.ioUnbind = function (eventName, io, callback) {
   }
   var events = ioEvents[eventName];
   if (!_.isEmpty(events)) {
-    if (callback && 'function' === typeof callback) {
-      for (var i = 0, l = events.length; i < l; i++) {
-        if (callback == events[i].cbLocal) {
-          this.unbind(events[i].name, events[i].cbLocal);
-          io.removeListener(events[i].global, events[i].cbGlobal);
-          events[i] = false;
+    if ('function' === typeof callback) {
+      _.each(events, function(event, index) {
+        if (callback == event.cbLocal) {
+          this.unbind(event.name, event.cbLocal);
+          io.removeListener(event.global, event.cbGlobal);
+          events.splice(index, 1);
         }
-      }
-      events = _.compact(events);
+      }, this);
     } else {
       this.unbind(eventName);
       io.removeAllListeners(globalName);


### PR DESCRIPTION
When a model is destroyed this patch will have it automatically unbind its socket. This also stops the event object from becoming populated with `false` elements after numerous unbinds
